### PR TITLE
Fix typo (OPENGL_INCLUDE_DIRS -> OPENGL_INCLUDE_DIR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(OpenGL REQUIRED)
 
 include_directories(
     ${SDL2_INCLUDE_DIRS}
-    ${OPENGL_INCLUDE_DIRS}
+    ${OPENGL_INCLUDE_DIR}
     Development/Source/Core/Geometry
     Development/Source/Core/Support
     Development/Source/Core/System


### PR DESCRIPTION
On platforms with the OpenGL libraries in the default `include` paths (e.g. `/usr/include`), there are no build issues. However, on FreeBSD the OpenGL libraries are in `/usr/local/include` and aren't picked up by default. This change (see [cmake documentation](https://cmake.org/cmake/help/latest/module/FindOpenGL.html#result-variables)) makes sure that the OpenGL libraries will be located.